### PR TITLE
test: Demonstrate issue with dataloader

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+
+function r() {
+  return Math.floor(Math.random() * 10000)
+}
+
+let count = 0
+
+app.get('/data/1234', (req, res) => {
+  console.log('Request number #' + count);
+
+  res.send(JSON.stringify({
+    id: 1234,
+    name: 'Example entity with random numbers',
+    lucky_numbers: [
+      r(),
+      r(),
+      r(),
+      r(),
+      r(),
+      r(),
+      r()
+    ],
+  }));
+  count++;
+});
+
+app.listen(3000, () => console.log('Example app listening on port 3000!'));
+

--- a/src/connector.js
+++ b/src/connector.js
@@ -6,5 +6,5 @@ export default class YourDataSourceConnector extends GraphQLConnector {
    * TODO: describe this API endpoint
    * @member {string}
    */
-  apiBaseUri = `https://example.org/v2`;
+  apiBaseUri = `http://localhost:3000`;
 }

--- a/test/connector.test.js
+++ b/test/connector.test.js
@@ -12,6 +12,6 @@ describe(`${DATA_SOURCE_NAME}Connector`, () => {
 
   it('uses the appropriate URL', () => {
     // TODO: Update the data source API endpoint.
-    expect(connector.apiBaseUri).toBe(`https://example.org/v2`);
+    expect(connector.apiBaseUri).toBe(`http://localhost:3000`);
   });
 });


### PR DESCRIPTION
@jlengstorf Attached is example code to demonstrate https://github.com/gramps-graphql/gramps-express/issues/47

Problem
=====
The purpose of the dataloader is to enable per-request caching. If I fetch an item by id "1234" twice in the same request, there should only be one request to the backend. However, fetching an item by id twice results in multiple backend calls.

Example
=====

Start the backend server in one terminal:

```bash
$ node server.js
Example app listening on port 3000!
```

Start the GraphQL server using live data:

```bash
$ yarn live-data
..
============================================================
    GrAMPS is running in live mode on port 8080

    GraphiQL: http://localhost:8080/graphiql
============================================================
```

Submit the following GraphQL request:

```graphql
query {
  hello:YourDataSource(id:"1234") {
    lucky_numbers
  }
  world:YourDataSource(id:"1234") {
    lucky_numbers
  }
}
```

And since the dataloader should cache the "1234" entity, I expect only one backend call and I expect the lucky_numbers arrays to be the same, even though lucky_numbers is an array of random numbers.

However, in server.js's logs, I can see two requests:

```bash
Request number #0
Request number #1
```

and in the JSON response:

```json
{
  "data": {
    "hello": {
      "lucky_numbers": [
        7844,
        9953,
        1779,
        7452,
        5061,
        8062,
        7354
      ]
    },
    "world": {
      "lucky_numbers": [
        6489,
        6526,
        1814,
        5528,
        8614,
        4666,
        4819
      ]
    }
  }
}
```

Solution
====
I believe the problem is that a new dataloader is constructed every time `connector.get()` is called, rather than once for every GraphQL request. I'm thinking connector's lifecycle needs to change to accommodate this.