### PR TITLE
feat: add install script for the GraphQL CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ cache:
   yarn: true
   directories:
   - node_modules
+env:
+  global:
+  # Code Climate is an excellent tool for tracking code quality.
+  # It’s free for open source, too! Set it up here: http://bit.ly/2l0mvp9
+  #
+  # To track code coverage, you’ll need this test reporter ID.
+  # Visit Settings => Test coverage on your Code Climate project dashboard
+  - CC_TEST_REPORTER_ID=
 node_js:
 - 6
 - 8
@@ -24,6 +32,3 @@ branches:
   only:
   - master
   - /^greenkeeper/.*$/
-env:
-  global:
-  - CC_TEST_REPORTER_ID=3f97d4ca639289c139796067359d46e7583e2d83701a315e40c1d1f58567afa8

--- a/install.js
+++ b/install.js
@@ -8,6 +8,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const globby = require('globby');
 const fs = require('fs');
+const pkg = require('./package.json');
 
 function replaceInFile(filePath, searchValue, replaceValue) {
   const contents = fs.readFileSync(filePath, 'utf8');
@@ -20,7 +21,7 @@ function replaceInFile(filePath, searchValue, replaceValue) {
 
 function replaceDefaultStringsInFiles(
   { namespace, prefix, templateName, project },
-  fileGlob = '{src,test}/**/*',
+  fileGlob = ['{src,test}/**/*', 'package.json'],
 ) {
   const sourceFiles = globby.sync(fileGlob);
   const newType = `${prefix}_${namespace}`;
@@ -52,9 +53,8 @@ const questions = [
 
 module.exports = async ({ project, context }) => {
   const opts = await context.prompt(questions);
-  const templateName = '@gramps/data-source-base';
 
-  replaceDefaultStringsInFiles({ ...opts, templateName, project });
+  replaceDefaultStringsInFiles({ ...opts, templateName: pkg.name, project });
 
   // eslint-disable-next-line no-console
   console.log(`

--- a/install.js
+++ b/install.js
@@ -1,0 +1,43 @@
+/**
+ * This is a helper file for use with the GraphQL CLI. It can be ignored if
+ * you’re not working with the GraphQL CLI.
+ *
+ * @see https://github.com/graphql-cli/graphql-cli
+ */
+const fs = require('fs');
+
+function replaceInFile(filePath, searchValue, replaceValue) {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  const newContents = contents.replace(
+    new RegExp(searchValue, 'g'),
+    replaceValue,
+  );
+  fs.writeFileSync(filePath, newContents);
+}
+
+module.exports = async ({ project, context }) => {
+  const opts = await context.prompt({
+    type: 'input',
+    name: 'test',
+    message: 'Do prompts work in the install script?',
+  });
+
+  console.log(opts);
+
+  const templateName = '@gramps/data-source-base';
+  replaceInFile('package.json', templateName, project);
+
+  console.log(`\
+💥 You’re all set: a new GrAMPS data source has been created!
+
+✅ Next steps:
+  1. Change directory: \`cd ${project}\`
+  2. Start local server: \`yarn dev\`
+  3. Open the GraphQL Playground: http://localhost:8080/playground
+
+💡 Don’t forget to update the following fields in \`package.json\`:
+  -  description
+  -  contributors
+  -  repository
+  `);
+};

--- a/install.js
+++ b/install.js
@@ -5,6 +5,7 @@
  * @see https://github.com/graphql-cli/graphql-cli
  */
 const fs = require('fs');
+const globby = require('globby');
 
 function replaceInFile(filePath, searchValue, replaceValue) {
   const contents = fs.readFileSync(filePath, 'utf8');
@@ -15,29 +16,55 @@ function replaceInFile(filePath, searchValue, replaceValue) {
   fs.writeFileSync(filePath, newContents);
 }
 
-module.exports = async ({ project, context }) => {
-  const opts = await context.prompt({
-    type: 'input',
-    name: 'test',
-    message: 'Do prompts work in the install script?',
+function replaceDefaultStringsInFiles(
+  { namespace, prefix, templateName, project },
+  fileGlob = '{src,test}/**/*',
+) {
+  const sourceFiles = globby.sync(fileGlob);
+  const newType = `${prefix}_${namespace}`;
+  const placeholder = `GrAMPS Data Source: ${namespace}`;
+
+  sourceFiles.forEach(filePath => {
+    replaceInFile(filePath, templateName, project);
+    replaceInFile(filePath, 'PFX_DataSourceBase', newType);
+    replaceInFile(filePath, 'DataSourceBase', namespace);
+    replaceInFile(filePath, 'GrAMPS GraphQL Data Source Base', placeholder);
   });
+}
 
-  console.log(opts);
+const questions = [
+  {
+    type: 'input',
+    name: 'namespace',
+    message: 'Choose a unique namespace. Only letters and numbers are allowed.',
+    default: 'MyDataSource',
+    validate: input => !input.match(/\W/),
+  },
+  {
+    type: 'input',
+    name: 'prefix',
+    message: 'Choose a short, unique prefix for your types.',
+    default: 'PFX',
+  },
+];
 
+module.exports = async ({ project, context }) => {
+  const opts = await context.prompt(questions);
   const templateName = '@gramps/data-source-base';
-  replaceInFile('package.json', templateName, project);
 
-  console.log(`\
-💥 You’re all set: a new GrAMPS data source has been created!
+  replaceDefaultStringsInFiles({ ...opts, templateName, project });
 
-✅ Next steps:
-  1. Change directory: \`cd ${project}\`
-  2. Start local server: \`yarn dev\`
-  3. Open the GraphQL Playground: http://localhost:8080/playground
+  console.log(`
 
-💡 Don’t forget to update the following fields in \`package.json\`:
-  -  description
-  -  contributors
-  -  repository
+💥  You’re all set: a new GrAMPS data source has been created!
+
+💡  Don’t forget to update "description", "contributors", and
+   "repository" in \`package.json\` with your own information.
+
+✅  Next steps:
+   1. Change directory: \`cd ${project}\`
+   2. Start local server: \`yarn dev\`
+   3. Open the GraphQL Playground: http://localhost:8080/playground
+   4. [BONUS] Set up Code Climate: http://bit.ly/2l0mvp9
   `);
 };

--- a/install.js
+++ b/install.js
@@ -4,8 +4,10 @@
  *
  * @see https://github.com/graphql-cli/graphql-cli
  */
-const fs = require('fs');
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 const globby = require('globby');
+const fs = require('fs');
 
 function replaceInFile(filePath, searchValue, replaceValue) {
   const contents = fs.readFileSync(filePath, 'utf8');
@@ -54,6 +56,7 @@ module.exports = async ({ project, context }) => {
 
   replaceDefaultStringsInFiles({ ...opts, templateName, project });
 
+  // eslint-disable-next-line no-console
   console.log(`
 
 💥  You’re all set: a new GrAMPS data source has been created!

--- a/install.js
+++ b/install.js
@@ -58,7 +58,6 @@ module.exports = async ({ project, context }) => {
 
   // eslint-disable-next-line no-console
   console.log(`
-
 💥  You’re all set: a new GrAMPS data source has been created!
 
 💡  Don’t forget to update "description", "contributors", and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gramps/data-source-base",
-  "description": "Base modules for a GrAMPS GraphQL data source.",
+  "description": "GrAMPS GraphQL Data Source Base",
   "contributors": [
     "Jason Lengstorf <jason@lengstorf.com>"
   ],
@@ -52,9 +52,11 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-prettier": "^2.4.0",
+    "globby": "^7.1.1",
     "graphql": "^0.12.3",
     "graphql-tools": "^2.14.1",
     "husky": "^0.14.3",
+    "inquirer": "^4.0.1",
     "jest": "^22.0.4",
     "prettier": "^1.9.2",
     "semantic-release": "^11.0.2"

--- a/src/context.js
+++ b/src/context.js
@@ -2,7 +2,7 @@
 export default {
   getById: id => ({
     id,
-    name: 'GrAMPS Data Source Base',
+    name: 'GrAMPS GraphQL Data Source Base',
     lucky_numbers: [1, 2, 3, 5, 8, 13, 21],
   }),
 };

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -5,7 +5,7 @@ describe('Data Source Context', () => {
     it('loads data by its ID', () => {
       expect(context.getById(123)).toEqual({
         id: 123,
-        name: 'GrAMPS Data Source Base',
+        name: 'GrAMPS GraphQL Data Source Base',
         lucky_numbers: [1, 2, 3, 5, 8, 13, 21],
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,9 @@
 import dataSource from '../src';
 
 // TODO: Update the data source name.
-const DATA_SOURCE_NAME = 'DataSourceBase';
-
-describe(`Data Source: ${DATA_SOURCE_NAME}`, () => {
+describe(`Data Source: DataSourceBase`, () => {
   it('contains a namespace property', () => {
-    expect(dataSource.namespace).toBe(DATA_SOURCE_NAME);
+    expect(dataSource.namespace).toBe('DataSourceBase');
   });
 
   it('contains a context property', () => {

--- a/test/mocks.test.js
+++ b/test/mocks.test.js
@@ -3,15 +3,13 @@ import expectMockList from './helpers/expectMockList';
 import mocks from '../src/mocks';
 
 describe('mock resolvers', () => {
-  /*
-    * So, basically mock resolvers just need to return values without
-    * exploding. To that end, we’ll just check that the mock response returns
-    * the proper fields.
-    */
   describe('PFX_DataSourceBase', () => {
     const mockResolvers = mocks.PFX_DataSourceBase();
 
+    // This helper creates a test to ensure each field has a mock resolver.
     expectMockFields(mockResolvers, ['id', 'name', 'lucky_numbers']);
+
+    // This helper creates a test to check that these fields return `MockList`s.
     expectMockList(mockResolvers, ['lucky_numbers']);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,6 +1230,10 @@ chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -2048,6 +2052,14 @@ external-editor@^2.0.4:
     jschardet "^1.4.2"
     tmp "^0.0.33"
 
+external-editor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2763,6 +2775,25 @@ inquirer@^3.0.6:
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
     external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-4.0.1.tgz#b25cd541789394b4bb56f6440fb213b121149096"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
     figures "^2.0.0"
     lodash "^4.3.0"
     mute-stream "0.0.7"


### PR DESCRIPTION
**IMPORTANT:** We can't merge this until (unless?) https://github.com/graphql-cli/graphql-cli/pull/79 is merged in.

This adds an install script that will:

- Update `package.json` with a new name and description
- Prompt the user for a prefix and namespace
- Replace the placeholder strings with user-supplied values

Current issues:

- [x] The CLI should ignore `install.js`